### PR TITLE
add PSEdition Desktop requirement

### DIFF
--- a/Add_Structure.ps1
+++ b/Add_Structure.ps1
@@ -1,4 +1,6 @@
-﻿Param (
+﻿#Requires -PSEdition Desktop
+
+Param (
 	[Switch]$NoSilent
 )
 

--- a/Remove_Structure.ps1
+++ b/Remove_Structure.ps1
@@ -1,3 +1,5 @@
+#Requires -PSEdition Desktop
+
 #***************************************************************************************************************
 # Author: Damien VAN ROBAEYS
 # Website: http://www.systanddeploy.com


### PR DESCRIPTION
I ran Add-Structures.ps1 on PowerShell 7 without knowing any better, which doesn't offer the `Get-WmiObject` or `Checkpoint-Computer` commands.

`#Requires -PSEdition Desktop` will prevent PowerShell 7 from running these scripts since it will require the Windows-specific version of PowerShell: 5.1